### PR TITLE
Add detailed JSDoc for prop interfaces

### DIFF
--- a/apps/web/src/components/EditorTabs.tsx
+++ b/apps/web/src/components/EditorTabs.tsx
@@ -13,22 +13,22 @@ import React, { useCallback } from 'react';
 export type TabType = 'note' | 'schema';
 
 /**
- * EditorTabsのprops型
- * @property {string | null} currentSchemaPath - 現在のスキーマパス（nullの場合はスキーマ未設定）
- * @property {TabType} activeTab - 現在アクティブなタブ
- * @property {(tab: TabType) => void} onTabChange - タブ切替時のハンドラ
- * @property {boolean} markdownDirty - マークダウンファイルの変更状態
- * @property {boolean} schemaDirty - スキーマファイルの変更状態
- * @property {string} markdownFileName - マークダウンファイルの名前
- * @property {string} schemaFileName - スキーマファイルの名前
+ * EditorTabs コンポーネントのプロパティ型
  */
 export interface EditorTabsProps {
+  /** 現在のスキーマパス（null の場合は未設定） */
   currentSchemaPath: string | null;
+  /** 現在アクティブなタブ */
   activeTab: TabType;
+  /** タブ切替時のハンドラ */
   onTabChange: (tab: TabType) => void;
+  /** マークダウンファイルの変更状態 */
   markdownDirty?: boolean;
+  /** スキーマファイルの変更状態 */
   schemaDirty?: boolean;
+  /** マークダウンファイルの名前 */
   markdownFileName?: string;
+  /** スキーマファイルの名前 */
   schemaFileName?: string;
 }
 
@@ -37,13 +37,6 @@ export interface EditorTabsProps {
  * 
  * @component
  * @param {EditorTabsProps} props - コンポーネントのプロパティ
- * @param {string | null} props.currentSchemaPath - 現在のスキーマパス（nullの場合はスキーマ未設定）
- * @param {TabType} props.activeTab - 現在アクティブなタブ
- * @param {function} props.onTabChange - タブ変更時のコールバック関数
- * @param {boolean} [props.markdownDirty] - マークダウンファイルの変更状態
- * @param {boolean} [props.schemaDirty] - スキーマファイルの変更状態
- * @param {string} [props.markdownFileName] - マークダウンファイルの名前
- * @param {string} [props.schemaFileName] - スキーマファイルの名前
  * @returns {JSX.Element} タブUIコンポーネント
  */
 export const EditorTabs: React.FC<EditorTabsProps> = ({

--- a/apps/web/src/components/ErrorBadge.tsx
+++ b/apps/web/src/components/ErrorBadge.tsx
@@ -11,11 +11,19 @@ type ErrorType =
   | 'other';
 import useLogger from '../hooks/useLogger';
 
+/**
+ * ErrorBadge コンポーネントのプロパティ型
+ */
 interface ErrorBadgeProps {
+  /** 表示するバリデーションエラー配列 */
   errors: ValidationError[];
+  /** エラー行クリック時のコールバック */
   onClick?: (line: number) => void;
+  /** 追加の CSS クラス */
   className?: string;
+  /** バッジタイプ */
   type?: 'frontmatter' | 'schema' | 'schemaValidation';
+  /** スキーマ検証エラーを表示するか */
   validated?: boolean;
 }
 
@@ -24,10 +32,6 @@ interface ErrorBadgeProps {
  *
  * @component
  * @param {ErrorBadgeProps} props - エラー情報とクリックハンドラ等
- * @param {ValidationError[]} props.errors - 表示するバリデーションエラー配列
- * @param {(line: number) => void} [props.onClick] - エラー行クリック時のコールバック
- * @param {string} [props.className] - 追加のCSSクラス
- * @param {boolean} [props.validated] - スキーマ検証が有効かどうか。falseの場合スキーマ検証エラーは表示されない
  * @returns {JSX.Element | null}
  *
  * @description

--- a/apps/web/src/components/MarkdownEditor.tsx
+++ b/apps/web/src/components/MarkdownEditor.tsx
@@ -12,12 +12,21 @@ import ErrorBadge from './ErrorBadge';
 import useLogger from '../hooks/useLogger';
 import { ValidationError } from '../hooks/validation-error.type';
 
+/**
+ * MarkdownEditor コンポーネントのプロパティ型
+ */
 interface MarkdownEditorProps {
+  /** 初期コンテンツ */
   initialContent: string;
+  /** 内容変更時のコールバック */
   onChange?: (content: string) => void;
+  /** 保存時のコールバック */
   onSave: (content: string) => void;
+  /** バリデーションエラー一覧 */
   validationErrors?: ValidationError[];
+  /** スキーマ検証が有効かどうか */
   validated?: boolean;
+  /** 現在開いているファイル名 */
   fileName?: string;
 }
 
@@ -26,12 +35,6 @@ interface MarkdownEditorProps {
  *
  * @component
  * @param {MarkdownEditorProps} props - コンポーネントのプロパティ
- * @param {string} props.initialContent - 初期コンテンツ
- * @param {function} props.onChange - 内容変更時のコールバック
- * @param {function} props.onSave - 保存時のコールバック
- * @param {ValidationError[]} [props.validationErrors] - バリデーションエラー一覧
- * @param {boolean} [props.validated] - スキーマ検証が有効かどうか
- * @param {string} [props.fileName] - 現在開いているファイル名
  * @returns {JSX.Element}
  *
  * @description

--- a/apps/web/src/components/SchemaEditor.tsx
+++ b/apps/web/src/components/SchemaEditor.tsx
@@ -12,12 +12,21 @@ import { ValidationError } from '../hooks/validation-error.type';
 import ErrorBadge from './ErrorBadge';
 import useLogger from '../hooks/useLogger';
 
+/**
+ * SchemaEditor コンポーネントのプロパティ型
+ */
 interface SchemaEditorProps {
+  /** スキーマファイルのパス */
   schemaPath: string;
+  /** 初期スキーマ内容 */
   initialSchema: string;
+  /** 保存時のコールバック */
   onSave: (content: string) => void;
+  /** エディタがアクティブかどうか */
   active: boolean;
+  /** 内容変更時のコールバック */
   onChange?: (content: string) => void;
+  /** 表示用ファイル名（File System Access API用） */
   fileName?: string;
 }
 
@@ -26,12 +35,6 @@ interface SchemaEditorProps {
  *
  * @component
  * @param {SchemaEditorProps} props - コンポーネントのプロパティ
- * @param {string} props.schemaPath - スキーマファイルのパス
- * @param {string} props.initialSchema - 初期スキーマ内容
- * @param {(content: string) => void} props.onSave - 保存時のコールバック関数
- * @param {boolean} props.active - アクティブかどうか
- * @param {(content: string) => void} [props.onChange] - 内容変更時のコールバック
- * @param {string} [props.fileName] - ファイル名（File System Access API用）
  * @returns {JSX.Element | null} スキーマエディタコンポーネント
  */
 export const SchemaEditor: React.FC<SchemaEditorProps> = ({

--- a/apps/web/src/components/ValidationToggle.tsx
+++ b/apps/web/src/components/ValidationToggle.tsx
@@ -7,9 +7,15 @@
 import React, { useCallback } from 'react';
 import useLogger from '../hooks/useLogger';
 
+/**
+ * ValidationToggle コンポーネントのプロパティ型
+ */
 export interface ValidationToggleProps {
+  /** 検証が有効かどうか */
   isValidated: boolean;
+  /** トグル時に呼ばれるハンドラ */
   onToggle: (isValidated: boolean) => void;
+  /** 操作不可状態か */
   isDisabled?: boolean;
 }
 

--- a/apps/web/src/contexts/LoggerContext.tsx
+++ b/apps/web/src/contexts/LoggerContext.tsx
@@ -31,19 +31,19 @@ export interface LogEvent {
 
 // ロガーコンテキストの型定義
 /**
- * LoggerContextで提供される関数・状態の型
- * @property {(level, action, details?) => void} log - ログ記録関数
- * @property {LogEvent[]} events - 現在のログイベント配列
- * @property {() => void} clearEvents - ログのクリア
- * @property {string} sessionId - セッションID
- * @property {() => string} exportLogs - ログのエクスポート（JSON文字列）
+ * LoggerContext で提供される関数・状態の型
  */
 export interface LoggerContextType {
+  /** ログ記録関数 */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   log: (level: LogLevel, action: string, details?: Record<string, any>) => void;
+  /** 現在のログイベント配列 */
   events: LogEvent[];
+  /** ログのクリア */
   clearEvents: () => void;
+  /** セッションID */
   sessionId: string;
+  /** ログを JSON 文字列でエクスポート */
   exportLogs: () => string;
 }
 


### PR DESCRIPTION
## Summary
- document each prop individually in EditorTabsProps
- add property docs to MarkdownEditorProps
- add property docs to SchemaEditorProps
- add property docs to ErrorBadgeProps
- document props for ValidationToggleProps
- document fields in LoggerContextType
- simplify component JSDoc `@param` sections

## Testing
- `pnpm test`
- `cargo test -p core-wasm`
