### PR TITLE
Add ErrorCode and propagate validation codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,29 @@ The project has completed all planned phases:
 | `FrontmatterValidation` | フロントマター検証エラー |
 | `SchemaValidation` | スキーマ検証エラー |
 | `Unknown` | その他のエラー |
+
+#### エラーコード変換メカニズム
+
+Rust/WASM 側では `ErrorCode` は数値として定義されていますが、TypeScript 側では文字列 Enum として定義されています。
+このギャップを埋めるため、`mapNumericToStringErrorCode` 関数を使用して数値から文字列への変換を行います。
+
+```typescript
+// 数値エラーコードを文字列に変換する関数
+export function mapNumericToStringErrorCode(code: unknown): ErrorCode {
+  if (typeof code !== 'number') {
+    return ErrorCode.Unknown;
+  }
+  
+  switch (code) {
+    case 0: return ErrorCode.YamlParse;
+    case 1: return ErrorCode.SchemaCompile;
+    case 2: return ErrorCode.FrontmatterParse;
+    case 3: return ErrorCode.FrontmatterValidation;
+    case 4: return ErrorCode.SchemaValidation;
+    case 5: default: return ErrorCode.Unknown;
+  }
+}
+```
+
+`ErrorBadge` コンポーネントでは、`normalizeErrorCode` ヘルパー関数を使って数値または文字列のエラーコードを正規化し、
+統一された方法でエラーコードを扱えるようにしています。

--- a/README.md
+++ b/README.md
@@ -86,3 +86,17 @@ The project has completed all planned phases:
 - **Core Logic**: Rust (compiled to WASM), serde_yaml, jsonschema-valid
 - **Build Tools**: pnpm, wasm-pack, Vite
 - **Future Plans**: Migration to Tauri for native capabilities
+
+### Error Codes
+
+`ErrorCode` enum は WASM とフロントエンドで共有されるバリデーションエラー種別です。
+現在定義されているコードは以下の通りです。
+
+| Code | Meaning |
+| ---- | ------- |
+| `YamlParse` | YAML 解析エラー |
+| `SchemaCompile` | スキーマコンパイル時のエラー |
+| `FrontmatterParse` | フロントマター解析エラー |
+| `FrontmatterValidation` | フロントマター検証エラー |
+| `SchemaValidation` | スキーマ検証エラー |
+| `Unknown` | その他のエラー |

--- a/apps/web/src/components/ErrorBadge.tsx
+++ b/apps/web/src/components/ErrorBadge.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { ValidationError } from '../hooks/validation-error.type';
+import { ValidationError, ErrorCode } from '../hooks/validation-error.type';
 
 // エラータイプのユニオン型を定義
 type ErrorType =
@@ -52,14 +52,9 @@ export const ErrorBadge: React.FC<ErrorBadgeProps> = ({
   useEffect(() => {
     // フィルタ済みのエラーを計算
     // validated=falseの場合、スキーマ検証エラーを除外する
-    const filteredErrors = validated 
-      ? errors 
-      : errors.filter(err => 
-          !(err.message.includes('スキーマ検証') || 
-            err.message.includes('Schema validation') ||
-            err.message.includes('required') ||
-            err.message.includes('type') ||
-            err.message.includes('pattern')));
+    const filteredErrors = validated
+      ? errors
+      : errors.filter(err => err.code !== ErrorCode.SchemaValidation);
 
     // 新しいエラーがある場合は表示
     if (filteredErrors.length > 0) {
@@ -68,21 +63,19 @@ export const ErrorBadge: React.FC<ErrorBadgeProps> = ({
       // エラータイプを集計
       const errorTypes = filteredErrors.reduce((acc: Record<ErrorType, number>, err) => {
         let type: ErrorType;
-        switch (true) {
-          case err.message.includes('フロントマター') || err.message.includes('Frontmatter'):
+        switch (err.code) {
+          case ErrorCode.FrontmatterParse:
+          case ErrorCode.FrontmatterValidation:
             type = 'frontmatter_error';
             break;
-          case err.message.includes('スキーマ検証') || err.message.includes('Schema validation'):
+          case ErrorCode.SchemaValidation:
+            if (err.message.includes('required')) type = 'required_field';
+            else if (err.message.includes('type')) type = 'type_mismatch';
+            else if (err.message.includes('pattern')) type = 'pattern_mismatch';
+            else type = 'schema_error';
+            break;
+          case ErrorCode.SchemaCompile:
             type = 'schema_error';
-            break;
-          case err.message.includes('required'):
-            type = 'required_field';
-            break;
-          case err.message.includes('type'):
-            type = 'type_mismatch';
-            break;
-          case err.message.includes('pattern'):
-            type = 'pattern_mismatch';
             break;
           default:
             type = 'other';
@@ -128,14 +121,9 @@ export const ErrorBadge: React.FC<ErrorBadgeProps> = ({
   }, [errors, log, validated]);
 
   // フィルタ済みのエラーを計算（表示判定時にも必要）
-  const filteredErrors = validated 
-    ? errors 
-    : errors.filter(err => 
-        !(err.message.includes('スキーマ検証') || 
-          err.message.includes('Schema validation') ||
-          err.message.includes('required') ||
-          err.message.includes('type') ||
-          err.message.includes('pattern')));
+  const filteredErrors = validated
+    ? errors
+    : errors.filter(err => err.code !== ErrorCode.SchemaValidation);
   
   // 表示されない場合は早期リターン
   if (!visible || filteredErrors.length === 0) {
@@ -158,27 +146,15 @@ export const ErrorBadge: React.FC<ErrorBadgeProps> = ({
   // エラータイプに基づいてクラスを返す関数
   const getErrorTypeClass = (error: ValidationError) => {
     // スキーマ構文エラー（紫）
-    if (
-      type === 'schema' ||
-      error.message.includes('スキーマ構文') ||
-      error.message.includes('Schema syntax')
-    ) {
+    if (type === 'schema' || error.code === ErrorCode.SchemaCompile) {
       return 'bg-purple-100 border-purple-400 text-purple-700';
     }
     // フロントマターエラー（赤）
-    else if (
-      type === 'frontmatter' ||
-      error.message.includes('フロントマター') ||
-      error.message.includes('Frontmatter')
-    ) {
+    else if (type === 'frontmatter' || error.code === ErrorCode.FrontmatterParse || error.code === ErrorCode.FrontmatterValidation) {
       return 'bg-red-100 border-red-400 text-red-700';
     }
     // スキーマ検証エラー（黄）
-    else if (
-      type === 'schemaValidation' ||
-      error.message.includes('スキーマ検証') ||
-      error.message.includes('Schema validation')
-    ) {
+    else if (type === 'schemaValidation' || error.code === ErrorCode.SchemaValidation) {
       return 'bg-yellow-100 border-yellow-400 text-yellow-700';
     }
     return 'bg-red-100 border-red-400 text-red-700'; // デフォルト（赤）
@@ -197,17 +173,15 @@ export const ErrorBadge: React.FC<ErrorBadgeProps> = ({
 
     // スキーマ構文エラー判定
     const hasSchemaStructureError = errors.some(
-      error => error.message.includes('スキーマ構文') || error.message.includes('Schema syntax')
+      error => error.code === ErrorCode.SchemaCompile
     );
 
-    // フロントマターエラー判定
     const hasFrontmatterError = errors.some(
-      error => error.message.includes('フロントマター') || error.message.includes('Frontmatter')
+      error => error.code === ErrorCode.FrontmatterParse || error.code === ErrorCode.FrontmatterValidation
     );
 
-    // スキーマ検証エラー判定
     const hasSchemaValidationError = errors.some(
-      error => error.message.includes('スキーマ検証') || error.message.includes('Schema validation')
+      error => error.code === ErrorCode.SchemaValidation
     );
 
     if (hasSchemaStructureError) {
@@ -247,17 +221,15 @@ export const ErrorBadge: React.FC<ErrorBadgeProps> = ({
 
     // スキーマ構文エラー判定
     const hasSchemaStructureError = errors.some(
-      error => error.message.includes('スキーマ構文') || error.message.includes('Schema syntax')
+      error => error.code === ErrorCode.SchemaCompile
     );
 
-    // フロントマターエラーがあるか確認
     const hasFrontmatterError = errors.some(
-      error => error.message.includes('フロントマター') || error.message.includes('Frontmatter')
+      error => error.code === ErrorCode.FrontmatterParse || error.code === ErrorCode.FrontmatterValidation
     );
 
-    // スキーマエラーがあるか確認
     const hasSchemaValidationError = errors.some(
-      error => error.message.includes('スキーマ検証') || error.message.includes('Schema validation')
+      error => error.code === ErrorCode.SchemaValidation
     );
 
     if (hasSchemaStructureError) {
@@ -358,12 +330,7 @@ export const ErrorBadge: React.FC<ErrorBadgeProps> = ({
    */
   const renderError = (error: ValidationError, index: number) => {
     // validated=falseの場合はスキーマ検証エラーを表示しない
-    if (!validated && 
-        (error.message.includes('スキーマ検証') || 
-         error.message.includes('Schema validation') ||
-         error.message.includes('required') ||
-         error.message.includes('type') ||
-         error.message.includes('pattern'))) {
+    if (!validated && error.code === ErrorCode.SchemaValidation) {
       return null;
     }
     
@@ -415,28 +382,23 @@ export const ErrorBadge: React.FC<ErrorBadgeProps> = ({
     // 標準の分類ロジック
     // スキーマ構文エラー
     const schemaStructureErrors = errors.filter(
-      error => error.message.includes('スキーマ構文') || error.message.includes('Schema syntax')
+      error => error.code === ErrorCode.SchemaCompile
     );
 
-    // フロントマターエラー
     const frontmatterErrors = errors.filter(
-      error => error.message.includes('フロントマター') || error.message.includes('Frontmatter')
+      error => error.code === ErrorCode.FrontmatterParse || error.code === ErrorCode.FrontmatterValidation
     );
 
-    // スキーマ検証エラー
     const schemaValidationErrors = errors.filter(
-      error => error.message.includes('スキーマ検証') || error.message.includes('Schema validation')
+      error => error.code === ErrorCode.SchemaValidation
     );
 
-    // その他のエラー
     const otherErrors = errors.filter(
       error =>
-        !error.message.includes('フロントマター') &&
-        !error.message.includes('Frontmatter') &&
-        !error.message.includes('スキーマ検証') &&
-        !error.message.includes('Schema validation') &&
-        !error.message.includes('スキーマ構文') &&
-        !error.message.includes('Schema syntax')
+        error.code !== ErrorCode.SchemaCompile &&
+        error.code !== ErrorCode.FrontmatterParse &&
+        error.code !== ErrorCode.FrontmatterValidation &&
+        error.code !== ErrorCode.SchemaValidation
     );
 
     return (

--- a/apps/web/src/components/SchemaEditor.tsx
+++ b/apps/web/src/components/SchemaEditor.tsx
@@ -8,7 +8,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import { yaml } from '@codemirror/lang-yaml';
 import { githubLight } from '@uiw/codemirror-theme-github';
 import { useYamlCore } from '../hooks/useYamlCore';
-import { ValidationError } from '../hooks/validation-error.type';
+import { ValidationError, ErrorCode } from '../hooks/validation-error.type';
 import ErrorBadge from './ErrorBadge';
 import useLogger from '../hooks/useLogger';
 
@@ -80,6 +80,7 @@ export const SchemaEditor: React.FC<SchemaEditorProps> = ({
             line: 0,
             message: `スキーマコンパイルエラー: ${error instanceof Error ? error.message : String(error)}`,
             path: '',
+            code: ErrorCode.SchemaCompile,
           },
         ]);
 

--- a/apps/web/src/components/__tests__/EditorTabs.test.tsx
+++ b/apps/web/src/components/__tests__/EditorTabs.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { EditorTabs } from '../EditorTabs';
-import { vi } from 'vitest';
+import { vi, describe, beforeEach, test, expect } from 'vitest';
 
 describe('EditorTabs', () => {
   const onTabChangeMock = vi.fn();

--- a/apps/web/src/components/__tests__/ErrorBadge.test.tsx
+++ b/apps/web/src/components/__tests__/ErrorBadge.test.tsx
@@ -1,31 +1,34 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import ErrorBadge from '../ErrorBadge';
-import { ValidationError } from '../../hooks/validation-error.type';
+import { ValidationError, ErrorCode } from '../../hooks/validation-error.type';
 import { LoggerProvider } from '../../contexts/LoggerContext';
 
 describe('ErrorBadge', () => {
   const mockErrors: ValidationError[] = [
-    { line: 1, message: 'Test error message 1', path: '/path1' },
-    { line: 5, message: 'Test error message 2', path: '/path2' },
+    { line: 1, message: 'Test error message 1', path: '/path1', code: ErrorCode.Unknown },
+    { line: 5, message: 'Test error message 2', path: '/path2', code: ErrorCode.Unknown },
   ];
 
   const frontmatterError: ValidationError = {
     line: 1,
     message: 'フロントマターエラー: 必須フィールドがありません',
     path: 'schema_path',
+    code: ErrorCode.FrontmatterValidation,
   };
 
   const schemaValidationError: ValidationError = {
     line: 5,
     message: 'スキーマ検証エラー: フィールドが必要です',
     path: 'title',
+    code: ErrorCode.SchemaValidation,
   };
 
   const schemaStructureError: ValidationError = {
     line: 2,
     message: 'スキーマ構文エラー: 無効なスキーマです',
     path: '',
+    code: ErrorCode.SchemaCompile,
   };
 
   it('renders errors correctly', () => {

--- a/apps/web/src/components/__tests__/MarkdownEditor.test.tsx
+++ b/apps/web/src/components/__tests__/MarkdownEditor.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import MarkdownEditor from '../MarkdownEditor';
 import { LoggerProvider } from '../../contexts/LoggerContext';
 import * as yamlCore from '../../hooks/useYamlCore';
+import { ErrorCode } from '../../hooks/validation-error.type';
 import { vi, beforeEach, describe, test, expect } from 'vitest';
 
 // YamlCoreモックの設定
@@ -104,6 +105,7 @@ validated: true
               line: 2,
               message: 'Frontmatter validation error: Invalid schema_path',
               path: 'schema_path',
+              code: ErrorCode.FrontmatterValidation,
             },
           ]}
         />

--- a/apps/web/src/components/__tests__/SchemaEditor.test.tsx
+++ b/apps/web/src/components/__tests__/SchemaEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { SchemaEditor } from '../SchemaEditor';
-import { vi } from 'vitest';
+import { vi, describe, test, beforeEach, expect } from 'vitest';
 
 // モックの作成
 vi.mock('../../hooks/useYamlCore', () => ({

--- a/apps/web/src/hooks/useValidator.ts
+++ b/apps/web/src/hooks/useValidator.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ValidationError } from './validation-error.type';
+import { ValidationError, ErrorCode } from './validation-error.type';
 import { useYamlCore } from './useYamlCore';
 import { fetchSchema } from '../utils/schema';
 import useLogger from './useLogger';
@@ -178,6 +178,7 @@ export const useValidator = (markdown: string) => {
                   ? `スキーマパスエラー: ${errorMessage}`
                   : `スキーマ検証エラー: ${errorMessage}`,
                 path: isAbsolutePathError ? 'schema_path' : '',
+                code: isAbsolutePathError ? ErrorCode.SchemaCompile : ErrorCode.SchemaValidation,
               });
 
               log('error', isAbsolutePathError ? 'schema_path_error' : 'schema_validation_error', {
@@ -208,6 +209,7 @@ export const useValidator = (markdown: string) => {
             line: 0,
             message: `検証エラー: ${error instanceof Error ? error.message : String(error)}`,
             path: '',
+            code: ErrorCode.Unknown,
           },
         ]);
 

--- a/apps/web/src/hooks/useYamlCore.ts
+++ b/apps/web/src/hooks/useYamlCore.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ValidationError, ErrorCode } from './validation-error.type';
+import { ValidationError, mapNumericToStringErrorCode } from './validation-error.type';
 
 /**
  * WASMコアモジュールの型定義
@@ -98,7 +98,7 @@ export function useYamlCore() {
             line: err.line || 0,
             message: err.message,
             path: err.path || '',
-            code: err.code || ErrorCode.Unknown,
+            code: mapNumericToStringErrorCode(err.code),
           }));
         }
 
@@ -163,7 +163,7 @@ export function useYamlCore() {
             line: err.line || 0,
             message: `スキーマ検証エラー: ${err.message}`,
             path: err.path || '',
-            code: err.code || ErrorCode.Unknown,
+            code: mapNumericToStringErrorCode(err.code),
           }));
         }
 
@@ -226,7 +226,7 @@ export function useYamlCore() {
               ? err.message
               : `スキーマ構文エラー: ${err.message}`,
             path: err.path || '',
-            code: err.code || ErrorCode.Unknown,
+            code: mapNumericToStringErrorCode(err.code),
           }));
         }
 

--- a/apps/web/src/hooks/useYamlCore.ts
+++ b/apps/web/src/hooks/useYamlCore.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ValidationError } from './validation-error.type';
+import { ValidationError, ErrorCode } from './validation-error.type';
 
 /**
  * WASMコアモジュールの型定義
@@ -98,6 +98,7 @@ export function useYamlCore() {
             line: err.line || 0,
             message: err.message,
             path: err.path || '',
+            code: err.code || ErrorCode.Unknown,
           }));
         }
 
@@ -162,6 +163,7 @@ export function useYamlCore() {
             line: err.line || 0,
             message: `スキーマ検証エラー: ${err.message}`,
             path: err.path || '',
+            code: err.code || ErrorCode.Unknown,
           }));
         }
 
@@ -224,6 +226,7 @@ export function useYamlCore() {
               ? err.message
               : `スキーマ構文エラー: ${err.message}`,
             path: err.path || '',
+            code: err.code || ErrorCode.Unknown,
           }));
         }
 

--- a/apps/web/src/hooks/validation-error.type.ts
+++ b/apps/web/src/hooks/validation-error.type.ts
@@ -9,4 +9,15 @@ export interface ValidationError {
   line: number;
   message: string;
   path: string;
+  code: ErrorCode;
+}
+
+/** バリデーションエラー種別 */
+export enum ErrorCode {
+  YamlParse = 'YamlParse',
+  SchemaCompile = 'SchemaCompile',
+  FrontmatterParse = 'FrontmatterParse',
+  FrontmatterValidation = 'FrontmatterValidation',
+  SchemaValidation = 'SchemaValidation',
+  Unknown = 'Unknown',
 }

--- a/apps/web/src/hooks/validation-error.type.ts
+++ b/apps/web/src/hooks/validation-error.type.ts
@@ -21,3 +21,31 @@ export enum ErrorCode {
   SchemaValidation = 'SchemaValidation',
   Unknown = 'Unknown',
 }
+
+/**
+ * Rust/WASMのエラーコードをTypeScriptの文字列エラーコードに変換
+ * 
+ * @param code - Rust側から返されるエラーコード（型は不明）
+ * @returns 対応するErrorCode列挙型の値
+ */
+export function mapNumericToStringErrorCode(code: unknown): ErrorCode {
+  if (typeof code !== 'number') {
+    return ErrorCode.Unknown;
+  }
+  
+  switch (code) {
+    case 0:
+      return ErrorCode.YamlParse;
+    case 1:
+      return ErrorCode.SchemaCompile;
+    case 2:
+      return ErrorCode.FrontmatterParse;
+    case 3:
+      return ErrorCode.FrontmatterValidation;
+    case 4:
+      return ErrorCode.SchemaValidation;
+    case 5:
+    default:
+      return ErrorCode.Unknown;
+  }
+}

--- a/apps/web/src/utils/__tests__/schema.test.ts
+++ b/apps/web/src/utils/__tests__/schema.test.ts
@@ -1,6 +1,7 @@
 import { fetchSchema, isAbsolutePath } from '../schema';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'vitest';
 
 // モックサーバーの設定
 const server = setupServer(

--- a/packages/core-wasm/pkg/core_wasm.d.ts
+++ b/packages/core-wasm/pkg/core_wasm.d.ts
@@ -1,13 +1,5 @@
 /* tslint:disable */
 /* eslint-disable */
-export enum ErrorCode {
-  YamlParse = "YamlParse",
-  SchemaCompile = "SchemaCompile",
-  FrontmatterParse = "FrontmatterParse",
-  FrontmatterValidation = "FrontmatterValidation",
-  SchemaValidation = "SchemaValidation",
-  Unknown = "Unknown"
-}
 /**
  * YAMLを指定されたスキーマに対してバリデーションする
  *
@@ -72,3 +64,34 @@ export function md_headings_to_yaml(md_str: string): string;
  * JSからのエラーメッセージをラップするためのコンバータ
  */
 export function error_to_js_value(error: any): string;
+/**
+ * バリデーションエラー種別を表すコード
+ *
+ * JS側でも利用できるよう `wasm_bindgen` で公開する
+ */
+export enum ErrorCode {
+  /**
+   * YAMLパースエラー
+   */
+  YamlParse = 0,
+  /**
+   * スキーマコンパイルエラー
+   */
+  SchemaCompile = 1,
+  /**
+   * フロントマターパースエラー
+   */
+  FrontmatterParse = 2,
+  /**
+   * フロントマター検証エラー
+   */
+  FrontmatterValidation = 3,
+  /**
+   * スキーマ検証エラー
+   */
+  SchemaValidation = 4,
+  /**
+   * 未分類のエラー
+   */
+  Unknown = 5,
+}

--- a/packages/core-wasm/pkg/core_wasm.d.ts
+++ b/packages/core-wasm/pkg/core_wasm.d.ts
@@ -1,5 +1,13 @@
 /* tslint:disable */
 /* eslint-disable */
+export enum ErrorCode {
+  YamlParse = "YamlParse",
+  SchemaCompile = "SchemaCompile",
+  FrontmatterParse = "FrontmatterParse",
+  FrontmatterValidation = "FrontmatterValidation",
+  SchemaValidation = "SchemaValidation",
+  Unknown = "Unknown"
+}
 /**
  * YAMLを指定されたスキーマに対してバリデーションする
  *

--- a/packages/core-wasm/src/error.rs
+++ b/packages/core-wasm/src/error.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
+use crate::error_code::ErrorCode;
+
 /// コアモジュールのエラー型
 ///
 /// # 概要
@@ -38,25 +40,33 @@ pub enum CoreError {
 /// - `line`: エラー発生行番号（0の場合は特定不可）
 /// - `message`: エラーメッセージ
 /// - `path`: エラー発生箇所のパス（YAML/JSON Pointer等）
+/// - `code`: エラー種別を表すコード
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorInfo {
     pub line: u32,
     pub message: String,
     pub path: String,
+    pub code: ErrorCode,
 }
 
 impl ErrorInfo {
     /// 新しいErrorInfoを生成
-    pub fn new(line: u32, message: impl Into<String>, path: impl Into<String>) -> Self {
+    pub fn new(
+        line: u32,
+        message: impl Into<String>,
+        path: impl Into<String>,
+        code: ErrorCode,
+    ) -> Self {
         Self {
             line,
             message: message.into(),
             path: path.into(),
+            code,
         }
     }
 
     /// serde_yaml::ErrorからErrorInfoを生成
-    pub fn from_yaml_error(error: &serde_yaml::Error) -> Self {
+    pub fn from_yaml_error(error: &serde_yaml::Error, code: ErrorCode) -> Self {
         let line = match error.location() {
             Some(location) => location.line() as u32,
             None => 0,
@@ -65,6 +75,7 @@ impl ErrorInfo {
             line,
             message: error.to_string(),
             path: "".to_string(),
+            code,
         }
     }
 }

--- a/packages/core-wasm/src/error_code.rs
+++ b/packages/core-wasm/src/error_code.rs
@@ -1,0 +1,22 @@
+use wasm_bindgen::prelude::*;
+use serde::{Serialize, Deserialize};
+
+/// バリデーションエラー種別を表すコード
+///
+/// JS側でも利用できるよう `wasm_bindgen` で公開する
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum ErrorCode {
+    /// YAMLパースエラー
+    YamlParse,
+    /// スキーマコンパイルエラー
+    SchemaCompile,
+    /// フロントマターパースエラー
+    FrontmatterParse,
+    /// フロントマター検証エラー
+    FrontmatterValidation,
+    /// スキーマ検証エラー
+    SchemaValidation,
+    /// 未分類のエラー
+    Unknown,
+}

--- a/packages/core-wasm/src/error_code.rs
+++ b/packages/core-wasm/src/error_code.rs
@@ -1,5 +1,5 @@
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
-use serde::{Serialize, Deserialize};
 
 /// バリデーションエラー種別を表すコード
 ///

--- a/packages/core-wasm/src/frontmatter.rs
+++ b/packages/core-wasm/src/frontmatter.rs
@@ -6,6 +6,7 @@
 //! - スキーマパスとバリデーションフラグの管理
 
 use crate::error::{CoreError, ErrorInfo, ValidationResult};
+use crate::error_code::ErrorCode;
 use serde::{Deserialize, Serialize};
 
 /// フロントマターの構造体
@@ -104,7 +105,8 @@ pub fn validate_frontmatter(frontmatter: &Frontmatter) -> ValidationResult {
             errors.push(ErrorInfo::new(
                 0,
                 "schema_pathが空です".to_string(),
-                "schema_path".to_string()
+                "schema_path".to_string(),
+                ErrorCode::FrontmatterValidation,
             ));
         }
     }

--- a/packages/core-wasm/src/lib.rs
+++ b/packages/core-wasm/src/lib.rs
@@ -16,10 +16,13 @@
 use wasm_bindgen::prelude::*;
 
 mod error;
+mod error_code;
 mod frontmatter;
 mod md_transform;
 mod schema_compile;
 mod validate;
+
+pub use error_code::ErrorCode;
 
 pub use error::{CoreError, ErrorInfo, ValidationResult};
 
@@ -80,7 +83,7 @@ pub fn parse_and_validate_frontmatter(md_str: &str) -> String {
             let validation_result = frontmatter::validate_frontmatter(&frontmatter);
             validation_result.to_json()
         }
-        Err(e) => ValidationResult::single_error(ErrorInfo::new(0, e.to_string(), "")).to_json(),
+        Err(e) => ValidationResult::single_error(ErrorInfo::new(0, e.to_string(), "", ErrorCode::FrontmatterParse)).to_json(),
     }
 }
 

--- a/packages/core-wasm/src/schema_compile.rs
+++ b/packages/core-wasm/src/schema_compile.rs
@@ -6,6 +6,7 @@
 
 use serde_json::Value;
 use crate::error::{ErrorInfo, ValidationResult};
+use crate::error_code::ErrorCode;
 
 /// JSONスキーマをコンパイルして検証する
 ///
@@ -29,12 +30,12 @@ pub fn compile_schema(schema_yaml: &str) -> String {
         Ok(value) => {
             // スキーマの基本検証
             if let Err(error) = validate_schema_basics(&value) {
-                return ValidationResult::error(vec![ErrorInfo::new(0, error, "")]).to_json();
+                return ValidationResult::error(vec![ErrorInfo::new(0, error, "", ErrorCode::SchemaCompile)]).to_json();
             }
 
             // メタスキーマによる検証
             if let Err(error) = validate_schema_structure(&value) {
-                return ValidationResult::error(vec![ErrorInfo::new(0, error, "")]).to_json();
+                return ValidationResult::error(vec![ErrorInfo::new(0, error, "", ErrorCode::SchemaCompile)]).to_json();
             }
 
             // 成功
@@ -51,7 +52,8 @@ pub fn compile_schema(schema_yaml: &str) -> String {
                 ErrorInfo::new(
                     line,
                     format!("スキーマ構文エラー: YAML解析に失敗しました - {}", err),
-                    ""
+                    "",
+                    ErrorCode::YamlParse,
                 )
             ]).to_json()
         }

--- a/packages/core-wasm/src/validate.rs
+++ b/packages/core-wasm/src/validate.rs
@@ -12,6 +12,7 @@
 //! WASMバインディング経由でJavaScriptから利用されることを想定しています。
 
 use crate::error::{ErrorInfo, ValidationResult};
+use crate::error_code::ErrorCode;
 use serde_json::Value;
 
 use jsonschema_valid::schemas::Draft;
@@ -38,7 +39,7 @@ pub fn validate_yaml(yaml_str: &str, schema_str: &str) -> String {
     let yaml_value: Value = match serde_yaml::from_str(yaml_str) {
         Ok(v) => v,
         Err(e) => {
-            return ValidationResult::error(vec![ErrorInfo::from_yaml_error(&e)]).to_json();
+            return ValidationResult::error(vec![ErrorInfo::from_yaml_error(&e, ErrorCode::YamlParse)]).to_json();
         }
     };
 
@@ -46,7 +47,7 @@ pub fn validate_yaml(yaml_str: &str, schema_str: &str) -> String {
     let schema_value: Value = match serde_yaml::from_str(schema_str) {
         Ok(v) => v,
         Err(e) => {
-            return ValidationResult::error(vec![ErrorInfo::from_yaml_error(&e)]).to_json();
+            return ValidationResult::error(vec![ErrorInfo::from_yaml_error(&e, ErrorCode::YamlParse)]).to_json();
         }
     };
 
@@ -58,6 +59,7 @@ pub fn validate_yaml(yaml_str: &str, schema_str: &str) -> String {
                 0,
                 format!("Schema compile error: {}", e),
                 "",
+                ErrorCode::SchemaCompile,
             )])
             .to_json();
         }
@@ -81,6 +83,7 @@ pub fn validate_yaml(yaml_str: &str, schema_str: &str) -> String {
                         line,
                         message: err.to_string(),
                         path,
+                        code: ErrorCode::SchemaValidation,
                     }
                 })
                 .collect();


### PR DESCRIPTION
## Summary
- expose `ErrorCode` enum from WASM and include in `ErrorInfo`
- parse error code in hooks and show badges based on the code
- update tests to handle the new field and fix tsconfig issues
- document error codes in README

## Testing
- `cargo test -p core-wasm`
- `pnpm test`
- `pnpm typecheck`
