### PR TITLE
Use proper CodeMirror refs

### DIFF
--- a/apps/web/src/components/MarkdownEditor.tsx
+++ b/apps/web/src/components/MarkdownEditor.tsx
@@ -4,7 +4,7 @@
  * File System Access APIを使ったファイル操作に対応
  */
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import CodeMirror from '@uiw/react-codemirror';
+import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { markdown } from '@codemirror/lang-markdown';
 import { githubLight } from '@uiw/codemirror-theme-github';
 import useValidator from '../hooks/useValidator';
@@ -52,7 +52,8 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   fileName = ''
 }) => {
   const [content, setContent] = useState<string>(initialContent);
-  const editorRef = useRef<any>(null);
+  // CodeMirror インスタンスへの参照
+  const editorRef = useRef<ReactCodeMirrorRef | null>(null);
   const { isValidating, clearErrors } = useValidator(content);
   const { log } = useLogger();
   const prevContentRef = useRef<string>('');

--- a/apps/web/src/components/SchemaEditor.tsx
+++ b/apps/web/src/components/SchemaEditor.tsx
@@ -4,7 +4,7 @@
  * File System Access APIを使ったファイル操作に対応
  */
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import CodeMirror from '@uiw/react-codemirror';
+import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { yaml } from '@codemirror/lang-yaml';
 import { githubLight } from '@uiw/codemirror-theme-github';
 import { useYamlCore } from '../hooks/useYamlCore';
@@ -50,7 +50,8 @@ export const SchemaEditor: React.FC<SchemaEditorProps> = ({
   const { wasmLoaded, compileSchema } = useYamlCore();
   const [isDirty, setIsDirty] = useState(false);
   const { log } = useLogger();
-  const editorRef = useRef<any>(null);
+  // CodeMirror インスタンスへの参照
+  const editorRef = useRef<ReactCodeMirrorRef | null>(null);
 
   // 初期スキーマが変更されたとき、内容を更新（保存されたスキーマの場合のみ）
   useEffect(() => {


### PR DESCRIPTION
## Summary
- switch to `useRef<ReactCodeMirrorRef | null>` for MarkdownEditor and SchemaEditor

## Testing
- `pnpm test`
- `cargo test -p core-wasm`
