### PR TITLE
Expose error structs to wasm

### DIFF
--- a/packages/core-wasm/pkg/core_wasm.d.ts
+++ b/packages/core-wasm/pkg/core_wasm.d.ts
@@ -95,3 +95,25 @@ export enum ErrorCode {
    */
   Unknown = 5,
 }
+
+/**
+ * フロントエンドに返すエラー情報
+ * バリデーションやパース時のエラー内容を保持するクラス
+ */
+export class ErrorInfo {
+  free(): void;
+  readonly line: number;
+  get message(): string;
+  get path(): string;
+  readonly code: ErrorCode;
+}
+
+/**
+ * フロントエンドに返す結果型
+ * バリデーション処理の成否とエラー一覧を提供するクラス
+ */
+export class ValidationResult {
+  free(): void;
+  readonly success: boolean;
+  get errors(): ErrorInfo[];
+}

--- a/packages/core-wasm/pkg/core_wasm.d.ts
+++ b/packages/core-wasm/pkg/core_wasm.d.ts
@@ -1,6 +1,10 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
+ * JSからのエラーメッセージをラップするためのコンバータ
+ */
+export function error_to_js_value(error: any): string;
+/**
  * YAMLを指定されたスキーマに対してバリデーションする
  *
  * # 引数
@@ -61,10 +65,6 @@ export function parse_and_validate_frontmatter(md_str: string): string;
  */
 export function md_headings_to_yaml(md_str: string): string;
 /**
- * JSからのエラーメッセージをラップするためのコンバータ
- */
-export function error_to_js_value(error: any): string;
-/**
  * バリデーションエラー種別を表すコード
  *
  * JS側でも利用できるよう `wasm_bindgen` で公開する
@@ -95,25 +95,35 @@ export enum ErrorCode {
    */
   Unknown = 5,
 }
-
 /**
  * フロントエンドに返すエラー情報
- * バリデーションやパース時のエラー内容を保持するクラス
+ * バリデーションやパース時のエラー情報
+ *
+ * # フィールド
+ * - `line`: エラー発生行番号（0の場合は特定不可）
+ * - `message`: エラーメッセージ
+ * - `path`: エラー発生箇所のパス（YAML/JSON Pointer等）
+ * - `code`: エラー種別を表すコード
  */
 export class ErrorInfo {
+  private constructor();
   free(): void;
   readonly line: number;
-  get message(): string;
-  get path(): string;
+  message: string;
+  path: string;
   readonly code: ErrorCode;
 }
-
 /**
  * フロントエンドに返す結果型
- * バリデーション処理の成否とエラー一覧を提供するクラス
+ * バリデーションの結果を表す構造体
+ *
+ * # フィールド
+ * - `success`: バリデーション成功時はtrue
+ * - `errors`: エラー情報の配列（成功時は空配列）
  */
 export class ValidationResult {
+  private constructor();
   free(): void;
   readonly success: boolean;
-  get errors(): ErrorInfo[];
+  errors: ErrorInfo[];
 }

--- a/packages/core-wasm/src/error.rs
+++ b/packages/core-wasm/src/error.rs
@@ -41,11 +41,16 @@ pub enum CoreError {
 /// - `message`: エラーメッセージ
 /// - `path`: エラー発生箇所のパス（YAML/JSON Pointer等）
 /// - `code`: エラー種別を表すコード
-#[derive(Debug, Serialize, Deserialize)]
+#[wasm_bindgen]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorInfo {
+    #[wasm_bindgen(readonly)]
     pub line: u32,
+    #[wasm_bindgen(getter_with_clone)]
     pub message: String,
+    #[wasm_bindgen(getter_with_clone)]
     pub path: String,
+    #[wasm_bindgen(readonly)]
     pub code: ErrorCode,
 }
 
@@ -86,9 +91,12 @@ impl ErrorInfo {
 /// # フィールド
 /// - `success`: バリデーション成功時はtrue
 /// - `errors`: エラー情報の配列（成功時は空配列）
-#[derive(Debug, Serialize, Deserialize)]
+#[wasm_bindgen]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationResult {
+    #[wasm_bindgen(readonly)]
     pub success: bool,
+    #[wasm_bindgen(getter_with_clone)]
     pub errors: Vec<ErrorInfo>,
 }
 


### PR DESCRIPTION
## Summary
- export `ErrorInfo` and `ValidationResult` via `wasm_bindgen`
- provide the corresponding TypeScript definitions

## Testing
- `pnpm test`
- `cargo test -p core-wasm`
