### PR TITLE
Add typed ValidationResult parsing

### DIFF
--- a/apps/web/src/hooks/useYamlCore.ts
+++ b/apps/web/src/hooks/useYamlCore.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ValidationError, mapNumericToStringErrorCode } from './validation-error.type';
+import {
+  ValidationError,
+  ValidationResult,
+  WasmErrorInfo,
+  mapNumericToStringErrorCode,
+} from './validation-error.type';
 
 /**
  * WASMコアモジュールの型定義
@@ -90,14 +95,14 @@ export function useYamlCore() {
       try {
         // WASMコア関数呼び出し
         const resultJson = instance.parse_and_validate_frontmatter(markdown);
-        const result = JSON.parse(resultJson);
+        const result = JSON.parse(resultJson) as ValidationResult;
 
         // 結果をValidationError[]形式に変換
         if (!result.success) {
-          return result.errors.map((err: any) => ({
-            line: err.line || 0,
+          return result.errors.map((err: WasmErrorInfo) => ({
+            line: err.line ?? 0,
             message: err.message,
-            path: err.path || '',
+            path: err.path ?? '',
             code: mapNumericToStringErrorCode(err.code),
           }));
         }
@@ -156,13 +161,13 @@ export function useYamlCore() {
 
       try {
         const resultJson = instance.validate_yaml(yaml, schema);
-        const result = JSON.parse(resultJson);
+        const result = JSON.parse(resultJson) as ValidationResult;
 
         if (!result.success) {
-          return result.errors.map((err: any) => ({
-            line: err.line || 0,
+          return result.errors.map((err: WasmErrorInfo) => ({
+            line: err.line ?? 0,
             message: `スキーマ検証エラー: ${err.message}`,
-            path: err.path || '',
+            path: err.path ?? '',
             code: mapNumericToStringErrorCode(err.code),
           }));
         }
@@ -217,15 +222,15 @@ export function useYamlCore() {
 
       try {
         const resultJson = instance.compile_schema(schemaYaml);
-        const result = JSON.parse(resultJson);
+        const result = JSON.parse(resultJson) as ValidationResult;
 
         if (!result.success) {
-          return result.errors.map((err: any) => ({
-            line: err.line || 0,
+          return result.errors.map((err: WasmErrorInfo) => ({
+            line: err.line ?? 0,
             message: err.message.startsWith('スキーマ構文エラー:')
               ? err.message
               : `スキーマ構文エラー: ${err.message}`,
-            path: err.path || '',
+            path: err.path ?? '',
             code: mapNumericToStringErrorCode(err.code),
           }));
         }

--- a/apps/web/src/hooks/validation-error.type.ts
+++ b/apps/web/src/hooks/validation-error.type.ts
@@ -23,6 +23,28 @@ export enum ErrorCode {
 }
 
 /**
+ * WASMから返されるエラー情報
+ *
+ * Rust側のErrorInfo構造体に対応する型定義
+ */
+export interface WasmErrorInfo {
+  line?: number;
+  message: string;
+  path?: string;
+  code: number;
+}
+
+/**
+ * WASMから返されるバリデーション結果
+ *
+ * successがtrueの場合はerrorsは空配列となる
+ */
+export interface ValidationResult {
+  success: boolean;
+  errors: WasmErrorInfo[];
+}
+
+/**
  * Rust/WASMのエラーコードをTypeScriptの文字列エラーコードに変換
  * 
  * @param code - Rust側から返されるエラーコード（型は不明）


### PR DESCRIPTION
## Summary
- define `WasmErrorInfo` and `ValidationResult` types
- parse `ValidationResult` objects from WASM results in `useYamlCore`

## Testing
- `pnpm test`
- `cargo test -p core-wasm`
