### PR TITLE
Fix import.meta env types and remove cast

### DIFF
--- a/apps/web/src/utils/schema.ts
+++ b/apps/web/src/utils/schema.ts
@@ -77,8 +77,7 @@ export const fetchSchema = async (schemaPath: string, basePath?: string): Promis
 
   try {
     // テストモードでは別のパス解決を使用します
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((import.meta as any).env?.MODE === 'test') {
+    if (import.meta.env?.MODE === 'test') {
       if (schemaPath.startsWith('./') && basePath) {
         const baseDir = basePath.substring(0, basePath.lastIndexOf('/') + 1);
         resolvedPath = baseDir + schemaPath.substring(2);

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -23,7 +23,8 @@
     },
     
     /* Type definitions */
-    "typeRoots": ["./node_modules/@types", "./src/types"]
+    "typeRoots": ["./node_modules/@types", "./src/types"],
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary
- add Vite client types to the web app tsconfig
- remove unnecessary `any` cast when checking `import.meta.env`

## Testing
- `pnpm test`
- `cargo test -p core-wasm`
