### PR TITLE
Fix react-refresh rule by moving context

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,7 +10,7 @@ import MarkdownEditor from './components/MarkdownEditor';
 import SchemaEditor from './components/SchemaEditor';
 import EditorTabs, { TabType } from './components/EditorTabs';
 import ValidationToggle from './components/ValidationToggle';
-import { LoggerProvider } from './contexts/LoggerContext';
+import { LoggerProvider } from './contexts/LoggerProvider';
 import useValidator from './hooks/useValidator';
 import { fetchSchema } from './utils/schema';
 import { useFileAccess } from './hooks/useFileAccess';

--- a/apps/web/src/components/__tests__/ErrorBadge.test.tsx
+++ b/apps/web/src/components/__tests__/ErrorBadge.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import ErrorBadge from '../ErrorBadge';
 import { ValidationError, ErrorCode } from '../../hooks/validation-error.type';
-import { LoggerProvider } from '../../contexts/LoggerContext';
+import { LoggerProvider } from '../../contexts/LoggerProvider';
 
 describe('ErrorBadge', () => {
   const mockErrors: ValidationError[] = [

--- a/apps/web/src/components/__tests__/MarkdownEditor.test.tsx
+++ b/apps/web/src/components/__tests__/MarkdownEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import MarkdownEditor from '../MarkdownEditor';
-import { LoggerProvider } from '../../contexts/LoggerContext';
+import { LoggerProvider } from '../../contexts/LoggerProvider';
 import * as yamlCore from '../../hooks/useYamlCore';
 import { ErrorCode } from '../../hooks/validation-error.type';
 import { vi, beforeEach, describe, test, expect } from 'vitest';

--- a/apps/web/src/components/__tests__/ValidationToggle.test.tsx
+++ b/apps/web/src/components/__tests__/ValidationToggle.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ValidationToggle } from '../ValidationToggle';
-import { LoggerProvider } from '../../contexts/LoggerContext';
+import { LoggerProvider } from '../../contexts/LoggerProvider';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
 describe('ValidationToggle', () => {

--- a/apps/web/src/contexts/LoggerContext.ts
+++ b/apps/web/src/contexts/LoggerContext.ts
@@ -1,0 +1,49 @@
+import { createContext } from 'react';
+
+/**
+ * ログレベルの型定義
+ * - debug: デバッグ情報
+ * - info: 通常の操作・情報
+ * - warn: 警告
+ * - error: エラー
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * ログイベント構造の定義
+ * @property {number} timestamp - イベント発生時刻（UNIXエポックms）
+ * @property {LogLevel} level - ログレベル
+ * @property {string} action - アクション名
+ * @property {Record<string, unknown>} [details] - 追加情報
+ * @property {string} sessionId - セッションID
+ */
+export interface LogEvent {
+  timestamp: number;
+  level: LogLevel;
+  action: string;
+  details?: Record<string, unknown>;
+  sessionId: string;
+}
+
+/**
+ * LoggerContext で提供される関数・状態の型
+ */
+export interface LoggerContextType {
+  /** ログ記録関数 */
+  log: (level: LogLevel, action: string, details?: Record<string, unknown>) => void;
+  /** 現在のログイベント配列 */
+  events: LogEvent[];
+  /** ログのクリア */
+  clearEvents: () => void;
+  /** セッションID */
+  sessionId: string;
+  /** ログを JSON 文字列でエクスポート */
+  exportLogs: () => string;
+}
+
+/**
+ * ログ機能を提供するReact Context
+ */
+export const LoggerContext = createContext<LoggerContextType | null>(null);
+
+

--- a/apps/web/src/contexts/LoggerProvider.tsx
+++ b/apps/web/src/contexts/LoggerProvider.tsx
@@ -1,56 +1,11 @@
-import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-
-// ログレベルの定義
-/**
- * ログレベルの型定義
- * - debug: デバッグ情報
- * - info: 通常の操作・情報
- * - warn: 警告
- * - error: エラー
- */
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
-
-// ログイベント構造の定義
-/**
- * ログイベント構造の定義
- * @property {number} timestamp - イベント発生時刻（UNIXエポックms）
- * @property {LogLevel} level - ログレベル
- * @property {string} action - アクション名
- * @property {Record<string, unknown>} [details] - 追加情報
- * @property {string} sessionId - セッションID
- */
-export interface LogEvent {
-  timestamp: number;
-  level: LogLevel;
-  action: string;
-  details?: Record<string, unknown>;
-  sessionId: string;
-}
-
-// ロガーコンテキストの型定義
-/**
- * LoggerContext で提供される関数・状態の型
- */
-export interface LoggerContextType {
-  /** ログ記録関数 */
-  log: (level: LogLevel, action: string, details?: Record<string, unknown>) => void;
-  /** 現在のログイベント配列 */
-  events: LogEvent[];
-  /** ログのクリア */
-  clearEvents: () => void;
-  /** セッションID */
-  sessionId: string;
-  /** ログを JSON 文字列でエクスポート */
-  exportLogs: () => string;
-}
-
-// コンテキストの作成
-/**
- * LoggerContext
- * ログ機能を提供するReact Context
- */
-export const LoggerContext = createContext<LoggerContextType | null>(null);
+import {
+  LoggerContext,
+  type LoggerContextType,
+  type LogEvent,
+  type LogLevel,
+} from './LoggerContext';
 
 // プロバイダーコンポーネント
 /**

--- a/apps/web/src/hooks/__tests__/useFileAccess.test.tsx
+++ b/apps/web/src/hooks/__tests__/useFileAccess.test.tsx
@@ -5,7 +5,7 @@
 
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useFileAccess } from '../useFileAccess';
-import { LoggerProvider } from '../../contexts/LoggerContext';
+import { LoggerProvider } from '../../contexts/LoggerProvider';
 import React from 'react';
 import { vi, describe, test, expect, beforeAll, beforeEach } from 'vitest';
 

--- a/apps/web/src/hooks/__tests__/useLogger.test.tsx
+++ b/apps/web/src/hooks/__tests__/useLogger.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { LoggerProvider } from '../../contexts/LoggerContext';
+import { LoggerProvider } from '../../contexts/LoggerProvider';
 import { useLogger } from '../useLogger';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 

--- a/apps/web/src/hooks/useLogger.ts
+++ b/apps/web/src/hooks/useLogger.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { LoggerContext, LoggerContextType } from '../contexts/LoggerContext';
+import { LoggerContext, type LoggerContextType } from '../contexts/LoggerContext';
 
 /**
  * ロガーフック

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { LoggerProvider } from './contexts/LoggerContext';
+import { LoggerProvider } from './contexts/LoggerProvider';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(


### PR DESCRIPTION
## Summary
- move `LoggerContext` and related types to a new file
- rename provider component file and update imports

## Testing
- `pnpm test`
- `cargo test -p core-wasm`
